### PR TITLE
Fix: 試験項目名の特殊文字を除去

### DIFF
--- a/main.py
+++ b/main.py
@@ -4,6 +4,7 @@ from openpyxl import Workbook
 from tkinter import Tk, Label, Button, Radiobutton, StringVar
 from tkinter.filedialog import askopenfilename
 import os
+import re  # Import the re module for regular expressions
 
 
 def get_excel_file_path():
@@ -29,6 +30,16 @@ def create_evidence_folder(directory_path):
             tkinter.messagebox.showerror("エラー", f"エビデンスフォルダを作成できませんでした。\n{e}")
             raise
     return evidence_folder_path
+
+
+def sanitize_filename(filename):
+    """
+    ファイル名から特殊文字を除去または置換する関数。
+    """
+    sanitized_filename = re.sub(r'[\\/:*?"<>|]', '', filename)
+    if sanitized_filename != filename:
+        print(f"警告: ファイル名に特殊文字が含まれていたため、修正されました。元のファイル名: {filename}, 修正後のファイル名: {sanitized_filename}")
+    return sanitized_filename
 
 
 def create_new_excel_with_sheets(mode):
@@ -89,7 +100,8 @@ def create_new_excel_with_sheets(mode):
         for test_item, test_numbers in test_item_dict.items():
             start_number = test_numbers[0]
             end_number = test_numbers[-1]
-            new_file_name = f"No.{start_number}~{end_number}_エビデンス_{test_item}.xlsx"
+            sanitized_test_item = sanitize_filename(test_item)  # サニタイズされた試験項目名を使用
+            new_file_name = f"No.{start_number}~{end_number}_エビデンス_{sanitized_test_item}.xlsx"
             new_file_path = os.path.join(evidence_folder_path, new_file_name)
 
             new_workbook = Workbook()


### PR DESCRIPTION
Fixes #8

テスト項目名に含まれる特殊文字に対応するため、ファイル名をサニタイズする機能を追加し、Excel作成ロジックを更新します。

**main.py**

- `sanitize_filename`関数を追加し、テスト項目名に含まれる特殊文字を削除または置換します。
- `create_new_excel_with_sheets`関数を更新し、新しいシートタイトルとファイル名を作成する際に`sanitize_filename`を使用するようにします。
- ファイル名に特殊文字が含まれている場合、警告メッセージをコンソールにログ出力します。

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/nakao-mz/ExcelSheetSplitter/pull/9?shareId=fbde2071-c8ea-4fbc-913c-5abff26ca155).